### PR TITLE
Change to toLocaleString for displaying dates by region

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -22,13 +22,13 @@ export function formatEta(seconds: number): string {
 
 export function formatDate(timestamp: number): string {
 	if (timestamp <= 0 || timestamp === -1) return '—'
-	const d = new Date(timestamp * 1000)
-	const day = d.getDate().toString().padStart(2, '0')
-	const month = (d.getMonth() + 1).toString().padStart(2, '0')
-	const year = d.getFullYear()
-	const hours = d.getHours().toString().padStart(2, '0')
-	const mins = d.getMinutes().toString().padStart(2, '0')
-	return `${day}/${month}/${year} ${hours}:${mins}`
+	return new Date(timestamp * 1000).toLocaleString(undefined, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: 'numeric',
+	})
 }
 
 export function formatDuration(seconds: number): string {


### PR DESCRIPTION
### Summary
Updated date formatting logic to be locale-aware using `Date.prototype.toLocaleString()`.

### Motivation
Previously, dates were hardcoded to a specific format (`DD/MM/YYYY HH:MM`), which could be confusing for users in regions with different conventions (e.g., US users expecting `MM/DD/YYYY`).

### Changes
- Modified [formatDate](cci:1://file:///Users/jason/src/qbitwebui/src/utils/format.ts:22:0-31:1) in [src/utils/format.ts](cci:7://file:///Users/jason/src/qbitwebui/src/utils/format.ts:0:0-0:0) to use the user's browser locale settings.
- Dates will now automatically adapt to the user's preferred format (e.g., `12/31/2024` for US, `31/12/2024` for UK/EU).
- Retained numeric components (Year, Month, Day, Hour, Minute) to maintain a consistent level of detail.