### PR TITLE
Allow changing save path and download path

### DIFF
--- a/__tests__/api/integrations.test.ts
+++ b/__tests__/api/integrations.test.ts
@@ -206,13 +206,13 @@ describe('integrations API', () => {
                 guid: 'abc123',
                 indexerId: 1,
                 downloadUrl: 'http://example.com/download',
-            }, 5)
+            }, 5, { savepath: '/downloads/complete', downloadPath: '/downloads/incomplete' })
 
             expect(mockFetch).toHaveBeenCalledWith('/api/integrations/1/grab', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
-                body: expect.stringContaining('"instanceId":5'),
+                body: expect.stringMatching(/"instanceId":5.*"savepath":"\/downloads\/complete".*"downloadPath":"\/downloads\/incomplete"|"instanceId":5.*"downloadPath":"\/downloads\/incomplete".*"savepath":"\/downloads\/complete"/),
             })
         })
 

--- a/__tests__/api/qbittorrent.test.ts
+++ b/__tests__/api/qbittorrent.test.ts
@@ -17,6 +17,8 @@ import {
     getTorrentTrackers,
     getTorrentFiles,
     renameTorrent,
+    setTorrentLocation,
+    setTorrentDownloadPath,
     addTrackers,
     removeTrackers,
     getPreferences,
@@ -166,6 +168,28 @@ describe('qBittorrent API', () => {
 
             const call = mockFetch.mock.calls[0]
             expect(call[1].body.get('deleteFiles')).toBe('true')
+        })
+
+	it('changes torrent save path', async () => {
+            mockFetch.mockResolvedValueOnce(jsonResponse({}))
+
+            await setTorrentLocation(instanceId, ['hash1', 'hash2'], '/downloads/new-path')
+
+            const call = mockFetch.mock.calls[0]
+            expect(call[0]).toBe('/api/instances/1/qbt/v2/torrents/setLocation')
+            expect(call[1].body.get('hashes')).toBe('hash1|hash2')
+            expect(call[1].body.get('location')).toBe('/downloads/new-path')
+        })
+
+        it('changes torrent download path', async () => {
+            mockFetch.mockResolvedValueOnce(jsonResponse({}))
+
+            await setTorrentDownloadPath(instanceId, ['hash1'], '/downloads/incomplete')
+
+            const call = mockFetch.mock.calls[0]
+            expect(call[0]).toBe('/api/instances/1/qbt/v2/torrents/setDownloadPath')
+            expect(call[1].body.get('hashes')).toBe('hash1')
+            expect(call[1].body.get('downloadPath')).toBe('/downloads/incomplete')
         })
     })
 

--- a/src/api/integrations.ts
+++ b/src/api/integrations.ts
@@ -120,7 +120,7 @@ export async function grabRelease(
 	integrationId: number,
 	release: { guid: string; indexerId: number; downloadUrl?: string; magnetUrl?: string },
 	instanceId: number,
-	options?: { category?: string; savepath?: string }
+	options?: { category?: string; savepath?: string; downloadPath?: string }
 ): Promise<void> {
 	const res = await fetch(`/api/integrations/${integrationId}/grab`, {
 		method: 'POST',

--- a/src/api/qbittorrent.ts
+++ b/src/api/qbittorrent.ts
@@ -273,6 +273,22 @@ export async function renameTorrent(instanceId: number, hash: string, name: stri
 	})
 }
 
+export async function setTorrentLocation(instanceId: number, hashes: string[], location: string): Promise<void> {
+	await action(instanceId, '/torrents/setLocation', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({ hashes: hashes.join('|'), location }),
+	})
+}
+
+export async function setTorrentDownloadPath(instanceId: number, hashes: string[], downloadPath: string): Promise<void> {
+	await action(instanceId, '/torrents/setDownloadPath', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({ hashes: hashes.join('|'), downloadPath }),
+	})
+}
+
 export async function addTrackers(instanceId: number, hash: string, urls: string[]): Promise<void> {
 	await action(instanceId, '/torrents/addTrackers', {
 		method: 'POST',

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -12,6 +12,8 @@ import {
 	useAddTags,
 	useRemoveTags,
 	useRenameTorrent,
+	useSetTorrentDownloadPath,
+	useSetTorrentLocation,
 	useExportTorrents,
 } from '../hooks/useTorrents'
 import type { Torrent } from '../types/qbittorrent'
@@ -24,11 +26,12 @@ interface Props {
 }
 
 type Submenu = 'category' | 'addTag' | 'removeTag' | 'delete' | null
+type EditorMode = 'rename' | 'savePath' | 'downloadPath' | null
 
 export function ContextMenu({ x, y, torrents, onClose }: Props) {
 	const [submenu, setSubmenu] = useState<Submenu>(null)
-	const [renaming, setRenaming] = useState(false)
-	const [newName, setNewName] = useState('')
+	const [editorMode, setEditorMode] = useState<EditorMode>(null)
+	const [inputValue, setInputValue] = useState('')
 	const ref = useRef<HTMLDivElement>(null)
 	const inputRef = useRef<HTMLInputElement>(null)
 
@@ -42,6 +45,8 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 	const addTagsMutation = useAddTags()
 	const removeTagsMutation = useRemoveTags()
 	const renameMutation = useRenameTorrent()
+	const setLocationMutation = useSetTorrentLocation()
+	const setDownloadPathMutation = useSetTorrentDownloadPath()
 	const deleteMutation = useDeleteTorrents()
 	const exportMutation = useExportTorrents()
 
@@ -70,11 +75,11 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 	}, [onClose])
 
 	useEffect(() => {
-		if (renaming && inputRef.current) {
+		if (editorMode && inputRef.current) {
 			inputRef.current.focus()
 			inputRef.current.select()
 		}
-	}, [renaming])
+	}, [editorMode])
 
 	const menuStyle: React.CSSProperties = {
 		position: 'fixed',
@@ -119,16 +124,45 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 		onClose()
 	}
 
-	function handleRename() {
-		if (isSingle && newName.trim()) {
-			renameMutation.mutate({ hash: hashes[0], name: newName.trim() })
+	function handleEditorSubmit() {
+		const value = inputValue.trim()
+		if (!value) return
+
+		if (editorMode === 'rename' && isSingle) {
+			renameMutation.mutate({ hash: hashes[0], name: value })
+			onClose()
+			return
+		}
+
+		if (editorMode === 'savePath') {
+			setLocationMutation.mutate({ hashes, location: value })
+			onClose()
+			return
+		}
+
+		if (editorMode === 'downloadPath') {
+			setDownloadPathMutation.mutate({ hashes, downloadPath: value })
 			onClose()
 		}
 	}
 
 	function startRename() {
-		setNewName(torrents[0].name)
-		setRenaming(true)
+		setInputValue(torrents[0].name)
+		setEditorMode('rename')
+		setSubmenu(null)
+	}
+
+	function startSetSavePath() {
+		const uniquePaths = new Set(torrents.map((torrent) => torrent.save_path).filter(Boolean))
+		setInputValue(uniquePaths.size === 1 ? torrents[0].save_path : '')
+		setEditorMode('savePath')
+		setSubmenu(null)
+	}
+
+	function startSetDownloadPath() {
+		const uniquePaths = new Set(torrents.map((torrent) => torrent.save_path).filter(Boolean))
+		setInputValue(uniquePaths.size === 1 ? torrents[0].save_path : '')
+		setEditorMode('downloadPath')
 		setSubmenu(null)
 	}
 
@@ -142,19 +176,34 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 		onClose()
 	}
 
-	if (renaming && isSingle) {
+	const editorTitle =
+		editorMode === 'rename'
+			? 'Rename torrent'
+			: editorMode === 'savePath'
+				? 'Change save path'
+				: 'Change download path'
+	const editorActionLabel = editorMode === 'rename' ? 'Rename' : 'Save'
+	const editorPlaceholder =
+		editorMode === 'rename'
+			? 'Enter torrent name'
+			: editorMode === 'savePath'
+				? 'Enter save path'
+				: 'Enter download path'
+
+	if (editorMode && (editorMode !== 'rename' || isSingle)) {
 		return (
 			<div ref={ref} className="rounded-lg border shadow-xl z-[200] p-3" style={menuStyle}>
 				<div className="text-xs font-medium mb-2" style={{ color: 'var(--text-muted)' }}>
-					Rename torrent
+					{editorTitle}
 				</div>
 				<input
 					ref={inputRef}
 					type="text"
-					value={newName}
-					onChange={(e) => setNewName(e.target.value)}
+					value={inputValue}
+					onChange={(e) => setInputValue(e.target.value)}
+					placeholder={editorPlaceholder}
 					onKeyDown={(e) => {
-						if (e.key === 'Enter') handleRename()
+						if (e.key === 'Enter') handleEditorSubmit()
 						if (e.key === 'Escape') onClose()
 					}}
 					className="w-full px-3 py-2 rounded-lg border text-sm mb-2"
@@ -169,11 +218,12 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 						Cancel
 					</button>
 					<button
-						onClick={handleRename}
+						onClick={handleEditorSubmit}
 						className="flex-1 py-1.5 rounded-lg text-xs"
+						disabled={!inputValue.trim()}
 						style={{ backgroundColor: 'var(--accent)', color: 'var(--accent-contrast)' }}
 					>
-						Rename
+						{editorActionLabel}
 					</button>
 				</div>
 			</div>
@@ -242,6 +292,8 @@ export function ContextMenu({ x, y, torrents, onClose }: Props) {
 					<MenuItem onClick={startRename}>Rename</MenuItem>
 				</>
 			)}
+			<MenuItem onClick={startSetSavePath}>Change Save Path</MenuItem>
+			<MenuItem onClick={startSetDownloadPath}>Change Download Path</MenuItem>
 			<div className="h-px my-1" style={{ backgroundColor: 'var(--border)' }} />
 			<MenuItem onClick={handleExport}>Export</MenuItem>
 			<MenuItem onClick={() => setSubmenu(submenu === 'delete' ? null : 'delete')} hasSubmenu>
@@ -283,3 +335,4 @@ function MenuItem({
 		</button>
 	)
 }
+

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -54,6 +54,7 @@ export function SearchPanel() {
 	const [grabCategories, setGrabCategories] = useState<Record<string, Category>>({})
 	const [grabCategory, setGrabCategory] = useState('')
 	const [grabSavepath, setGrabSavepath] = useState('')
+	const [grabDownloadPath, setGrabDownloadPath] = useState('')
 	const [loadingCategories, setLoadingCategories] = useState(false)
 	const [sortKey, setSortKey] = useState<SortKey>('seeders')
 	const [sortAsc, setSortAsc] = useState(false)
@@ -186,6 +187,7 @@ export function SearchPanel() {
 		setGrabModal(result)
 		setGrabCategory('')
 		setGrabSavepath('')
+		setGrabDownloadPath('')
 		if (instances.length === 1) {
 			setGrabInstance(instances[0].id)
 		} else {
@@ -199,6 +201,7 @@ export function SearchPanel() {
 		setGrabCategories({})
 		setGrabCategory('')
 		setGrabSavepath('')
+		setGrabDownloadPath('')
 		setInstanceDropdownOpen(false)
 		setCategoryDropdownOpen(false)
 	}
@@ -207,9 +210,10 @@ export function SearchPanel() {
 		if (!selectedIntegration || !grabModal || !grabInstance) return
 		setGrabbing(grabModal.guid)
 		setGrabResult(null)
-		const options: { category?: string; savepath?: string } = {}
+		const options: { category?: string; savepath?: string; downloadPath?: string } = {}
 		if (grabCategory) options.category = grabCategory
 		if (grabSavepath.trim()) options.savepath = grabSavepath.trim()
+		if (grabDownloadPath.trim()) options.downloadPath = grabDownloadPath.trim()
 		try {
 			await grabRelease(
 				selectedIntegration.id,
@@ -1063,6 +1067,27 @@ export function SearchPanel() {
 									}}
 								/>
 							</div>
+							<div>
+								<label
+									className="block text-xs font-medium mb-2 uppercase tracking-wider"
+									style={{ color: 'var(--text-muted)' }}
+								>
+									Download Path
+								</label>
+								<input
+									type="text"
+									value={grabDownloadPath}
+									onChange={(e) => setGrabDownloadPath(e.target.value)}
+									disabled={!grabInstance}
+									placeholder="Default"
+									className="w-full px-3 py-2 rounded-lg border text-sm disabled:opacity-50"
+									style={{
+										backgroundColor: 'var(--bg-tertiary)',
+										borderColor: 'var(--border)',
+										color: 'var(--text-primary)',
+									}}
+								/>
+							</div>
 						</div>
 						<div className="flex gap-3 justify-end mt-6">
 							<button
@@ -1087,3 +1112,4 @@ export function SearchPanel() {
 		</div>
 	)
 }
+

--- a/src/components/TorrentDetailsPanel.tsx
+++ b/src/components/TorrentDetailsPanel.tsx
@@ -150,18 +150,21 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 	const setDownloadPathMutation = useSetTorrentDownloadPath()
 	if (isLoading) return <LoadingSkeleton />
 	if (!p) return <EmptyState message="Failed to load" />
+	const properties = p
 
 	const ratio =
-		p.total_downloaded === 0 && p.pieces_have === p.pieces_num && p.total_size > 0 ? '∞' : p.share_ratio.toFixed(2)
+		properties.total_downloaded === 0 && properties.pieces_have === properties.pieces_num && properties.total_size > 0
+			? '∞'
+			: properties.share_ratio.toFixed(2)
 
 	const timeActive =
-		p.seeding_time > 0
-			? `${formatDuration(p.time_elapsed)} (seeded ${formatDuration(p.seeding_time)})`
-			: formatDuration(p.time_elapsed)
+		properties.seeding_time > 0
+			? `${formatDuration(properties.time_elapsed)} (seeded ${formatDuration(properties.seeding_time)})`
+			: formatDuration(properties.time_elapsed)
 	const pathMutationPending = setLocationMutation.isPending || setDownloadPathMutation.isPending
 
 	function openEditor(mode: 'savePath' | 'downloadPath') {
-		setInputValue(p.save_path)
+		setInputValue(properties.save_path)
 		setEditorMode(mode)
 	}
 
@@ -192,37 +195,37 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 				</legend>
 				<div className="grid grid-cols-12 gap-1.5">
 					<InfoCell label="Time Active" value={timeActive} span={2} />
-					<InfoCell label="ETA" value={formatEta(p.eta)} span={2} />
-					<InfoCell label="Connections" value={`${p.nb_connections} (${p.nb_connections_limit} max)`} span={2} />
-					<InfoCell label="Seeds" value={`${p.seeds} (${p.seeds_total} total)`} span={2} />
-					<InfoCell label="Peers" value={`${p.peers} (${p.peers_total} total)`} span={2} />
-					<InfoCell label="Wasted" value={formatSize(p.total_wasted)} span={2} />
+					<InfoCell label="ETA" value={formatEta(properties.eta)} span={2} />
+					<InfoCell label="Connections" value={`${properties.nb_connections} (${properties.nb_connections_limit} max)`} span={2} />
+					<InfoCell label="Seeds" value={`${properties.seeds} (${properties.seeds_total} total)`} span={2} />
+					<InfoCell label="Peers" value={`${properties.peers} (${properties.peers_total} total)`} span={2} />
+					<InfoCell label="Wasted" value={formatSize(properties.total_wasted)} span={2} />
 					<InfoCell
 						label="Downloaded"
-						value={`${formatSize(p.total_downloaded)} (${formatSize(p.total_downloaded_session)} session)`}
+						value={`${formatSize(properties.total_downloaded)} (${formatSize(properties.total_downloaded_session)} session)`}
 						span={2}
 					/>
 					<InfoCell
 						label="Uploaded"
-						value={`${formatSize(p.total_uploaded)} (${formatSize(p.total_uploaded_session)} session)`}
+						value={`${formatSize(properties.total_uploaded)} (${formatSize(properties.total_uploaded_session)} session)`}
 						span={2}
 					/>
 					<InfoCell
 						label="DL Speed"
-						value={`${formatSpeed(p.dl_speed)} (${formatSpeed(p.dl_speed_avg)} avg)`}
+						value={`${formatSpeed(properties.dl_speed)} (${formatSpeed(properties.dl_speed_avg)} avg)`}
 						span={2}
 					/>
 					<InfoCell
 						label="UP Speed"
-						value={`${formatSpeed(p.up_speed)} (${formatSpeed(p.up_speed_avg)} avg)`}
+						value={`${formatSpeed(properties.up_speed)} (${formatSpeed(properties.up_speed_avg)} avg)`}
 						span={2}
 					/>
-					<InfoCell label="DL Limit" value={formatLimit(p.dl_limit)} span={2} />
-					<InfoCell label="UP Limit" value={formatLimit(p.up_limit)} span={2} />
+					<InfoCell label="DL Limit" value={formatLimit(properties.dl_limit)} span={2} />
+					<InfoCell label="UP Limit" value={formatLimit(properties.up_limit)} span={2} />
 					<InfoCell label="Ratio" value={ratio} span={3} />
-					<InfoCell label="Reannounce" value={p.reannounce > 0 ? formatDuration(p.reannounce) : '0'} span={3} />
-					<InfoCell label="Last Seen Complete" value={p.last_seen > 0 ? formatDate(p.last_seen) : 'Never'} span={3} />
-					<InfoCell label="Popularity" value={p.popularity !== undefined ? p.popularity.toFixed(2) : '—'} span={3} />
+					<InfoCell label="Reannounce" value={properties.reannounce > 0 ? formatDuration(properties.reannounce) : '0'} span={3} />
+					<InfoCell label="Last Seen Complete" value={properties.last_seen > 0 ? formatDate(properties.last_seen) : 'Never'} span={3} />
+					<InfoCell label="Popularity" value={properties.popularity !== undefined ? properties.popularity.toFixed(2) : '—'} span={3} />
 				</div>
 			</fieldset>
 
@@ -234,22 +237,22 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 					Information
 				</legend>
 				<div className="grid grid-cols-6 gap-1.5">
-					<InfoCell label="Total Size" value={formatSize(p.total_size)} />
-					<InfoCell label="Pieces" value={`${p.pieces_num} × ${formatSize(p.piece_size)} (have ${p.pieces_have})`} />
-					<InfoCell label="Created By" value={p.created_by || '—'} />
-					<InfoCell label="Added On" value={formatDate(p.addition_date)} />
-					<InfoCell label="Completed On" value={p.completion_date > 0 ? formatDate(p.completion_date) : '—'} />
-					<InfoCell label="Created On" value={p.creation_date > 0 ? formatDate(p.creation_date) : '—'} />
-					<InfoCell label="Private" value={p.is_private ? 'Yes' : 'No'} accent={p.is_private} span={2} />
+					<InfoCell label="Total Size" value={formatSize(properties.total_size)} />
+					<InfoCell label="Pieces" value={`${properties.pieces_num} × ${formatSize(properties.piece_size)} (have ${properties.pieces_have})`} />
+					<InfoCell label="Created By" value={properties.created_by || '—'} />
+					<InfoCell label="Added On" value={formatDate(properties.addition_date)} />
+					<InfoCell label="Completed On" value={properties.completion_date > 0 ? formatDate(properties.completion_date) : '—'} />
+					<InfoCell label="Created On" value={properties.creation_date > 0 ? formatDate(properties.creation_date) : '—'} />
+					<InfoCell label="Private" value={properties.is_private ? 'Yes' : 'No'} accent={properties.is_private} span={2} />
 					<InfoCell label="Category" value={category || '—'} span={2} />
 					<InfoCell label="Tags" value={tags || '—'} span={2} />
 				</div>
 				<div className="grid grid-cols-2 gap-1.5 mt-1.5">
-					<InfoCell label="Info Hash v1" value={p.infohash_v1 || hash} wide />
-					<InfoCell label="Info Hash v2" value={p.infohash_v2 || 'N/A'} muted={!p.infohash_v2} wide />
+					<InfoCell label="Info Hash v1" value={properties.infohash_v1 || hash} wide />
+					<InfoCell label="Info Hash v2" value={properties.infohash_v2 || 'N/A'} muted={!properties.infohash_v2} wide />
 				</div>
 				<div className="mt-1.5">
-					<InfoCell label="Save Path" value={p.save_path} wide />
+					<InfoCell label="Save Path" value={properties.save_path} wide />
 				</div>
 				<div className="flex flex-wrap gap-2 mt-1.5">
 					<button
@@ -309,9 +312,9 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 						</div>
 					</div>
 				)}
-				{p.comment && (
+				{properties.comment && (
 					<div className="mt-1.5">
-						<InfoCell label="Comment" value={p.comment} wide />
+						<InfoCell label="Comment" value={properties.comment} wide />
 					</div>
 				)}
 			</fieldset>
@@ -882,4 +885,5 @@ export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onTo
 		</div>
 	)
 }
+
 

--- a/src/components/TorrentDetailsPanel.tsx
+++ b/src/components/TorrentDetailsPanel.tsx
@@ -254,6 +254,11 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 				<div className="mt-1.5">
 					<InfoCell label="Save Path" value={properties.save_path} wide />
 				</div>
+				{properties.download_path && (
+					<div className="mt-1.5">
+						<InfoCell label="Download Path" value={properties.download_path} wide />
+					</div>
+				)}
 				<div className="flex flex-wrap gap-2 mt-1.5">
 					<button
 						onClick={() => openEditor('savePath')}

--- a/src/components/TorrentDetailsPanel.tsx
+++ b/src/components/TorrentDetailsPanel.tsx
@@ -23,6 +23,7 @@ import {
 	useAddTrackers,
 	useRemoveTrackers,
 } from '../hooks/useTorrentDetails'
+import { useSetTorrentDownloadPath, useSetTorrentLocation } from '../hooks/useTorrents'
 import { formatSize, formatSpeed, formatDate, formatDuration, formatEta } from '../utils/format'
 import type { Tracker, Peer } from '../types/torrentDetails'
 import { buildFileTree, flattenVisibleNodes, getInitialExpanded } from '../utils/fileTree'
@@ -142,7 +143,11 @@ function InfoCell({
 }
 
 function GeneralTab({ hash, category, tags }: { hash: string; category: string; tags: string }) {
+	const [editorMode, setEditorMode] = useState<'savePath' | 'downloadPath' | null>(null)
+	const [inputValue, setInputValue] = useState('')
 	const { data: p, isLoading } = useTorrentProperties(hash)
+	const setLocationMutation = useSetTorrentLocation()
+	const setDownloadPathMutation = useSetTorrentDownloadPath()
 	if (isLoading) return <LoadingSkeleton />
 	if (!p) return <EmptyState message="Failed to load" />
 
@@ -153,6 +158,28 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 		p.seeding_time > 0
 			? `${formatDuration(p.time_elapsed)} (seeded ${formatDuration(p.seeding_time)})`
 			: formatDuration(p.time_elapsed)
+	const pathMutationPending = setLocationMutation.isPending || setDownloadPathMutation.isPending
+
+	function openEditor(mode: 'savePath' | 'downloadPath') {
+		setInputValue(p.save_path)
+		setEditorMode(mode)
+	}
+
+	function handlePathSave() {
+		const trimmed = inputValue.trim()
+		if (!trimmed) return
+
+		if (editorMode === 'savePath') {
+			setLocationMutation.mutate({ hashes: [hash], location: trimmed })
+			setEditorMode(null)
+			return
+		}
+
+		if (editorMode === 'downloadPath') {
+			setDownloadPathMutation.mutate({ hashes: [hash], downloadPath: trimmed })
+			setEditorMode(null)
+		}
+	}
 
 	return (
 		<div className="p-3 overflow-auto h-full space-y-3">
@@ -224,6 +251,64 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 				<div className="mt-1.5">
 					<InfoCell label="Save Path" value={p.save_path} wide />
 				</div>
+				<div className="flex flex-wrap gap-2 mt-1.5">
+					<button
+						onClick={() => openEditor('savePath')}
+						disabled={pathMutationPending}
+						className="px-2.5 py-1.5 rounded text-[10px] font-medium disabled:opacity-50"
+						style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-primary)' }}
+					>
+						Change Save Path
+					</button>
+					<button
+						onClick={() => openEditor('downloadPath')}
+						disabled={pathMutationPending}
+						className="px-2.5 py-1.5 rounded text-[10px] font-medium disabled:opacity-50"
+						style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-primary)' }}
+					>
+						Change Download Path
+					</button>
+				</div>
+				{editorMode && (
+					<div className="mt-1.5 rounded border p-2 space-y-2" style={{ ...cellBase }}>
+						<div className="text-[9px] uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
+							{editorMode === 'savePath' ? 'Change Save Path' : 'Change Download Path'}
+						</div>
+						<input
+							type="text"
+							value={inputValue}
+							onChange={(e) => setInputValue(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter') handlePathSave()
+								if (e.key === 'Escape') setEditorMode(null)
+							}}
+							className="w-full px-3 py-2 rounded border text-xs"
+							style={{
+								backgroundColor: 'var(--bg-secondary)',
+								borderColor: 'var(--border)',
+								color: 'var(--text-primary)',
+							}}
+							autoFocus
+						/>
+						<div className="flex gap-2">
+							<button
+								onClick={() => setEditorMode(null)}
+								className="px-2.5 py-1.5 rounded text-[10px] font-medium"
+								style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-muted)' }}
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handlePathSave}
+								disabled={!inputValue.trim() || pathMutationPending}
+								className="px-2.5 py-1.5 rounded text-[10px] font-medium disabled:opacity-50"
+								style={{ backgroundColor: 'var(--accent)', color: 'var(--accent-contrast)' }}
+							>
+								{pathMutationPending ? 'Saving...' : 'Save'}
+							</button>
+						</div>
+					</div>
+				)}
 				{p.comment && (
 					<div className="mt-1.5">
 						<InfoCell label="Comment" value={p.comment} wide />
@@ -797,3 +882,4 @@ export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onTo
 		</div>
 	)
 }
+

--- a/src/components/TorrentList.tsx
+++ b/src/components/TorrentList.tsx
@@ -492,10 +492,10 @@ export function TorrentList() {
 	return (
 		<div className="flex flex-col flex-1 overflow-hidden" style={{ backgroundColor: 'var(--bg-primary)' }}>
 			<div
-				className="flex items-center gap-1 px-2 py-1.5 border-b"
+				className="flex items-center gap-1 px-2 py-1.5 border-b overflow-x-auto"
 				style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
 			>
-				<div className="flex items-center">
+				<div className="flex items-center shrink-0">
 					<ActionButton
 						onClick={() => setAddModal(true)}
 						disabled={false}
@@ -526,23 +526,23 @@ export function TorrentList() {
 					/>
 				</div>
 
-				<div className="w-px h-5" style={{ backgroundColor: 'var(--border)' }} />
+				<div className="w-px h-5 shrink-0" style={{ backgroundColor: 'var(--border)' }} />
 
-				<div className="flex items-center">
+				<div className="flex items-center shrink-0">
 					<FilterBar filter={filter} onFilterChange={setFilter} />
 				</div>
 
-				<div className="w-px h-5" style={{ backgroundColor: 'var(--border)' }} />
+				<div className="w-px h-5 shrink-0" style={{ backgroundColor: 'var(--border)' }} />
 
-				<div className="flex items-center">
+				<div className="flex items-center shrink-0">
 					<CategoryDropdown value={categoryFilter} onChange={setCategoryFilter} categories={categories} />
 					<TagDropdown value={tagFilter} onChange={setTagFilter} tags={tags} />
 					<TrackerDropdown value={trackerFilter} onChange={setTrackerFilter} trackers={uniqueTrackers} />
 				</div>
 
-				<div className="w-px h-5" style={{ backgroundColor: 'var(--border)' }} />
+				<div className="w-px h-5 shrink-0" style={{ backgroundColor: 'var(--border)' }} />
 
-				<div className="flex items-center">
+				<div className="flex items-center shrink-0">
 					<ViewSelector
 						views={customViews}
 						isModified={isViewModified}
@@ -563,9 +563,11 @@ export function TorrentList() {
 					/>
 				</div>
 
-				<div className="flex-1 min-w-0" />
+				<div className="flex-1 min-w-4" />
 
-				<SearchInput value={search} onChange={setSearch} />
+				<div className="shrink-0">
+					<SearchInput value={search} onChange={setSearch} />
+				</div>
 			</div>
 
 			<div
@@ -875,3 +877,4 @@ export function TorrentList() {
 		</div>
 	)
 }
+

--- a/src/hooks/useTorrents.ts
+++ b/src/hooks/useTorrents.ts
@@ -125,6 +125,32 @@ export function useRenameTorrent() {
 	})
 }
 
+export function useSetTorrentLocation() {
+	const instance = useInstance()
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: ({ hashes, location }: { hashes: string[]; location: string }) =>
+			api.setTorrentLocation(instance.id, hashes, location),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['torrents', instance.id] })
+			queryClient.invalidateQueries({ queryKey: ['torrent-properties', instance.id] })
+		},
+	})
+}
+
+export function useSetTorrentDownloadPath() {
+	const instance = useInstance()
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: ({ hashes, downloadPath }: { hashes: string[]; downloadPath: string }) =>
+			api.setTorrentDownloadPath(instance.id, hashes, downloadPath),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['torrents', instance.id] })
+			queryClient.invalidateQueries({ queryKey: ['torrent-properties', instance.id] })
+		},
+	})
+}
+
 export function useCreateTag() {
 	const instance = useInstance()
 	const queryClient = useQueryClient()

--- a/src/mobile/MobileSearchPanel.tsx
+++ b/src/mobile/MobileSearchPanel.tsx
@@ -59,6 +59,7 @@ export function MobileSearchPanel({ instances, onBack }: Props) {
 	const [grabCategories, setGrabCategories] = useState<Record<string, Category>>({})
 	const [grabCategory, setGrabCategory] = useState('')
 	const [grabSavepath, setGrabSavepath] = useState('')
+	const [grabDownloadPath, setGrabDownloadPath] = useState('')
 	const [loadingCategories, setLoadingCategories] = useState(false)
 	const [showIndexerPicker, setShowIndexerPicker] = useState(false)
 	const [showIntegrationPicker, setShowIntegrationPicker] = useState(false)
@@ -107,6 +108,7 @@ export function MobileSearchPanel({ instances, onBack }: Props) {
 		if (!showGrabSheet) return
 		setGrabCategory('')
 		setGrabSavepath('')
+		setGrabDownloadPath('')
 		setGrabInstance(instances.length === 1 ? instances[0].id : null)
 	}, [showGrabSheet, instances])
 
@@ -185,9 +187,10 @@ export function MobileSearchPanel({ instances, onBack }: Props) {
 		if (!selectedIntegration) return
 		setGrabbing(result.guid)
 		setGrabResult(null)
-		const options: { category?: string; savepath?: string } = {}
+		const options: { category?: string; savepath?: string; downloadPath?: string } = {}
 		if (grabCategory) options.category = grabCategory
 		if (grabSavepath.trim()) options.savepath = grabSavepath.trim()
+		if (grabDownloadPath.trim()) options.downloadPath = grabDownloadPath.trim()
 		try {
 			await grabRelease(
 				selectedIntegration.id,
@@ -912,6 +915,24 @@ export function MobileSearchPanel({ instances, onBack }: Props) {
 									}}
 								/>
 							</div>
+							<div>
+								<div className="text-xs font-medium px-1 pb-2" style={{ color: 'var(--text-muted)' }}>
+									Download Path
+								</div>
+								<input
+									type="text"
+									value={grabDownloadPath}
+									onChange={(e) => setGrabDownloadPath(e.target.value)}
+									disabled={!grabInstance}
+									placeholder="Default"
+									className="w-full px-4 py-3 rounded-xl border text-base disabled:opacity-50"
+									style={{
+										backgroundColor: 'var(--bg-secondary)',
+										borderColor: 'var(--border)',
+										color: 'var(--text-primary)',
+									}}
+								/>
+							</div>
 							<button
 								onClick={() => grabInstance && handleGrab(showGrabSheet, grabInstance)}
 								disabled={!grabInstance || grabbing === showGrabSheet.guid}
@@ -1131,3 +1152,4 @@ export function MobileSearchPanel({ instances, onBack }: Props) {
 		</div>
 	)
 }
+

--- a/src/mobile/MobileTorrentDetail.tsx
+++ b/src/mobile/MobileTorrentDetail.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from 'vaul'
-import { Play, Pause, Trash2 } from 'lucide-react'
+import { Play, Pause, Trash2, FolderInput, Download } from 'lucide-react'
 import * as api from '../api/qbittorrent'
 import type { TorrentState } from '../types/qbittorrent'
 import { formatSize, formatSpeed, formatDate, formatDuration } from '../utils/format'
 
 type Tab = 'general' | 'files' | 'trackers' | 'peers' | 'http'
+type PathEditorMode = 'savePath' | 'downloadPath' | null
 
 const PAUSED_STATES: TorrentState[] = ['pausedDL', 'pausedUP', 'stoppedDL', 'stoppedUP']
 
@@ -43,6 +44,8 @@ interface Props {
 export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props) {
 	const [tab, setTab] = useState<Tab>('general')
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+	const [pathEditorMode, setPathEditorMode] = useState<PathEditorMode>(null)
+	const [pathValue, setPathValue] = useState('')
 	const [deleteFiles, setDeleteFiles] = useState(false)
 	const queryClient = useQueryClient()
 
@@ -97,6 +100,20 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 		mutationFn: (deleteFiles: boolean) => api.deleteTorrents(instanceId, [torrentHash], deleteFiles),
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['torrents', instanceId] }),
 	})
+	const setLocationMutation = useMutation({
+		mutationFn: (location: string) => api.setTorrentLocation(instanceId, [torrentHash], location),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['torrents', instanceId] })
+			queryClient.invalidateQueries({ queryKey: ['torrent-properties', instanceId, torrentHash] })
+		},
+	})
+	const setDownloadPathMutation = useMutation({
+		mutationFn: (downloadPath: string) => api.setTorrentDownloadPath(instanceId, [torrentHash], downloadPath),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['torrents', instanceId] })
+			queryClient.invalidateQueries({ queryKey: ['torrent-properties', instanceId, torrentHash] })
+		},
+	})
 
 	const isPaused = torrent ? PAUSED_STATES.includes(torrent.state) : false
 	const peers = peersData?.peers ? Object.values(peersData.peers) : []
@@ -113,6 +130,32 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 		deleteMutation.mutate(deleteFiles)
 		onClose()
 	}
+
+	function openPathEditor(mode: Exclude<PathEditorMode, null>) {
+		setPathValue(torrent?.save_path ?? '')
+		setPathEditorMode(mode)
+	}
+
+	function handlePathSave() {
+		const trimmed = pathValue.trim()
+		if (!trimmed) return
+
+		if (pathEditorMode === 'savePath') {
+			setLocationMutation.mutate(trimmed, {
+				onSuccess: () => setPathEditorMode(null),
+			})
+			return
+		}
+
+		if (pathEditorMode === 'downloadPath') {
+			setDownloadPathMutation.mutate(trimmed, {
+				onSuccess: () => setPathEditorMode(null),
+			})
+		}
+	}
+
+	const pathMutationPending = setLocationMutation.isPending || setDownloadPathMutation.isPending
+	const pathEditorTitle = pathEditorMode === 'savePath' ? 'Change Save Path' : 'Change Download Path'
 
 	const tabs: { id: Tab; label: string; count?: number }[] = [
 		{ id: 'general', label: 'General' },
@@ -206,6 +249,27 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							>
 								<Trash2 className="w-5 h-5" strokeWidth={2} />
 								Delete
+							</button>
+						</div>
+
+						<div className="grid grid-cols-2 gap-3 px-4 pb-4 border-b" style={{ borderColor: 'var(--border)' }}>
+							<button
+								onClick={() => openPathEditor('savePath')}
+								disabled={pathMutationPending}
+								className="py-3 rounded-xl font-medium text-sm flex items-center justify-center gap-2 active:scale-[0.98] transition-transform disabled:opacity-50"
+								style={{ backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-primary)' }}
+							>
+								<FolderInput className="w-5 h-5" strokeWidth={1.8} />
+								Save Path
+							</button>
+							<button
+								onClick={() => openPathEditor('downloadPath')}
+								disabled={pathMutationPending}
+								className="py-3 rounded-xl font-medium text-sm flex items-center justify-center gap-2 active:scale-[0.98] transition-transform disabled:opacity-50"
+								style={{ backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-primary)' }}
+							>
+								<Download className="w-5 h-5" strokeWidth={1.8} />
+								Download Path
 							</button>
 						</div>
 
@@ -394,6 +458,55 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 				</Drawer.Portal>
 			</Drawer.Root>
 
+			{pathEditorMode && (
+				<>
+					<div
+						className="fixed inset-0 z-[60]"
+						style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+						onClick={() => !pathMutationPending && setPathEditorMode(null)}
+					/>
+					<div
+						className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[60] rounded-2xl border p-5"
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+					>
+						<h3 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
+							{pathEditorTitle}
+						</h3>
+						<input
+							type="text"
+							value={pathValue}
+							onChange={(e) => setPathValue(e.target.value)}
+							onKeyDown={(e) => e.key === 'Enter' && handlePathSave()}
+							className="w-full px-4 py-3 rounded-xl border text-base"
+							style={{
+								backgroundColor: 'var(--bg-tertiary)',
+								borderColor: 'var(--border)',
+								color: 'var(--text-primary)',
+							}}
+							autoFocus
+						/>
+						<div className="flex gap-3 mt-5">
+							<button
+								onClick={() => setPathEditorMode(null)}
+								disabled={pathMutationPending}
+								className="flex-1 py-3 rounded-xl text-sm font-medium disabled:opacity-50"
+								style={{ backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-primary)' }}
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handlePathSave}
+								disabled={!pathValue.trim() || pathMutationPending}
+								className="flex-1 py-3 rounded-xl text-sm font-medium disabled:opacity-50"
+								style={{ backgroundColor: 'var(--accent)', color: 'var(--accent-contrast)' }}
+							>
+								{pathMutationPending ? 'Saving...' : 'Save'}
+							</button>
+						</div>
+					</div>
+				</>
+			)}
+
 			{showDeleteConfirm && (
 				<>
 					<div
@@ -470,3 +583,4 @@ function InfoRow({
 		</div>
 	)
 }
+

--- a/src/mobile/MobileTorrentDetail.tsx
+++ b/src/mobile/MobileTorrentDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from 'vaul'
 import { Play, Pause, Trash2, FolderInput, Download } from 'lucide-react'
@@ -176,8 +177,8 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 	return (
 		<>
 			<Drawer.Root
-				open={!showDeleteConfirm}
-				onOpenChange={(open) => !open && !showDeleteConfirm && onClose()}
+				open={!showDeleteConfirm && !pathEditorMode}
+				onOpenChange={(open) => !open && !showDeleteConfirm && !pathEditorMode && onClose()}
 				shouldScaleBackground={false}
 			>
 				<Drawer.Portal>
@@ -459,9 +460,9 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 				</Drawer.Portal>
 			</Drawer.Root>
 
-			{pathEditorMode && (
+			{pathEditorMode && createPortal(
 				<div
-					className="fixed inset-0 z-[60] flex items-center justify-center"
+					className="fixed inset-0 z-[9999] flex items-center justify-center"
 					style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
 					onClick={() => !pathMutationPending && setPathEditorMode(null)}
 				>
@@ -474,17 +475,19 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							{pathEditorTitle}
 						</h3>
 						<input
+							ref={(el) => { if (el) setTimeout(() => el.focus(), 50) }}
 							type="text"
 							value={pathValue}
 							onChange={(e) => setPathValue(e.target.value)}
 							onKeyDown={(e) => e.key === 'Enter' && handlePathSave()}
+							onTouchEnd={(e) => { e.stopPropagation(); (e.target as HTMLInputElement).focus() }}
 							className="w-full px-4 py-3 rounded-xl border text-base"
 							style={{
 								backgroundColor: 'var(--bg-tertiary)',
 								borderColor: 'var(--border)',
 								color: 'var(--text-primary)',
+								fontSize: '16px',
 							}}
-							autoFocus
 						/>
 						<div className="flex gap-3 mt-5">
 							<button
@@ -505,12 +508,13 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							</button>
 						</div>
 					</div>
-				</div>
+				</div>,
+				document.body
 			)}
 
-			{showDeleteConfirm && (
+			{showDeleteConfirm && createPortal(
 				<div
-					className="fixed inset-0 z-[60] flex items-center justify-center"
+					className="fixed inset-0 z-[9999] flex items-center justify-center"
 					style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
 					onClick={() => setShowDeleteConfirm(false)}
 				>
@@ -553,7 +557,8 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							</button>
 						</div>
 					</div>
-				</div>
+				</div>,
+				document.body
 			)}
 		</>
 	)
@@ -584,6 +589,4 @@ function InfoRow({
 		</div>
 	)
 }
-
-
 

--- a/src/mobile/MobileTorrentDetail.tsx
+++ b/src/mobile/MobileTorrentDetail.tsx
@@ -323,6 +323,7 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 									<InfoRow label="Category" value={torrent.category || '-'} />
 									<InfoRow label="Tags" value={torrent.tags || '-'} />
 									<InfoRow label="Save Path" value={torrent.save_path} small />
+									{torrent.download_path && <InfoRow label="Download Path" value={torrent.download_path} small />}
 									{properties?.comment && <InfoRow label="Comment" value={properties.comment} small />}
 								</div>
 							)}
@@ -462,12 +463,21 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 				<>
 					<div
 						className="fixed inset-0 z-[60]"
-						style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+						style={{ backgroundColor: 'rgba(0,0,0,0.6)', touchAction: 'none' }}
 						onClick={() => !pathMutationPending && setPathEditorMode(null)}
+						onTouchStart={(e) => { e.preventDefault(); e.stopPropagation() }}
+						onTouchMove={(e) => { e.preventDefault(); e.stopPropagation() }}
+						onTouchEnd={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							if (!pathMutationPending) setPathEditorMode(null)
+						}}
 					/>
 					<div
 						className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[60] rounded-2xl border p-5"
-						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)', touchAction: 'auto' }}
+						onTouchStart={(e) => e.stopPropagation()}
+						onTouchMove={(e) => e.stopPropagation()}
 					>
 						<h3 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
 							{pathEditorTitle}
@@ -511,12 +521,21 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 				<>
 					<div
 						className="fixed inset-0 z-[60]"
-						style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+						style={{ backgroundColor: 'rgba(0,0,0,0.6)', touchAction: 'none' }}
 						onClick={() => setShowDeleteConfirm(false)}
+						onTouchStart={(e) => { e.preventDefault(); e.stopPropagation() }}
+						onTouchMove={(e) => { e.preventDefault(); e.stopPropagation() }}
+						onTouchEnd={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							setShowDeleteConfirm(false)
+						}}
 					/>
 					<div
 						className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[60] rounded-2xl border p-5"
-						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)', touchAction: 'auto' }}
+						onTouchStart={(e) => e.stopPropagation()}
+						onTouchMove={(e) => e.stopPropagation()}
 					>
 						<h3 className="text-lg font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>
 							Delete Torrent
@@ -583,4 +602,5 @@ function InfoRow({
 		</div>
 	)
 }
+
 

--- a/src/mobile/MobileTorrentDetail.tsx
+++ b/src/mobile/MobileTorrentDetail.tsx
@@ -460,24 +460,15 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 			</Drawer.Root>
 
 			{pathEditorMode && (
-				<>
+				<div
+					className="fixed inset-0 z-[60] flex items-center justify-center"
+					style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+					onClick={() => !pathMutationPending && setPathEditorMode(null)}
+				>
 					<div
-						className="fixed inset-0 z-[60]"
-						style={{ backgroundColor: 'rgba(0,0,0,0.6)', touchAction: 'none' }}
-						onClick={() => !pathMutationPending && setPathEditorMode(null)}
-						onTouchStart={(e) => { e.preventDefault(); e.stopPropagation() }}
-						onTouchMove={(e) => { e.preventDefault(); e.stopPropagation() }}
-						onTouchEnd={(e) => {
-							e.preventDefault()
-							e.stopPropagation()
-							if (!pathMutationPending) setPathEditorMode(null)
-						}}
-					/>
-					<div
-						className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[60] rounded-2xl border p-5"
-						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)', touchAction: 'auto' }}
-						onTouchStart={(e) => e.stopPropagation()}
-						onTouchMove={(e) => e.stopPropagation()}
+						className="mx-4 w-full max-w-lg rounded-2xl border p-5"
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+						onClick={(e) => e.stopPropagation()}
 					>
 						<h3 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
 							{pathEditorTitle}
@@ -514,28 +505,19 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							</button>
 						</div>
 					</div>
-				</>
+				</div>
 			)}
 
 			{showDeleteConfirm && (
-				<>
+				<div
+					className="fixed inset-0 z-[60] flex items-center justify-center"
+					style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+					onClick={() => setShowDeleteConfirm(false)}
+				>
 					<div
-						className="fixed inset-0 z-[60]"
-						style={{ backgroundColor: 'rgba(0,0,0,0.6)', touchAction: 'none' }}
-						onClick={() => setShowDeleteConfirm(false)}
-						onTouchStart={(e) => { e.preventDefault(); e.stopPropagation() }}
-						onTouchMove={(e) => { e.preventDefault(); e.stopPropagation() }}
-						onTouchEnd={(e) => {
-							e.preventDefault()
-							e.stopPropagation()
-							setShowDeleteConfirm(false)
-						}}
-					/>
-					<div
-						className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[60] rounded-2xl border p-5"
-						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)', touchAction: 'auto' }}
-						onTouchStart={(e) => e.stopPropagation()}
-						onTouchMove={(e) => e.stopPropagation()}
+						className="mx-4 w-full max-w-lg rounded-2xl border p-5"
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+						onClick={(e) => e.stopPropagation()}
 					>
 						<h3 className="text-lg font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>
 							Delete Torrent
@@ -571,7 +553,7 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 							</button>
 						</div>
 					</div>
-				</>
+				</div>
 			)}
 		</>
 	)
@@ -602,5 +584,6 @@ function InfoRow({
 		</div>
 	)
 }
+
 
 

--- a/src/server/routes/integrations.ts
+++ b/src/server/routes/integrations.ts
@@ -212,6 +212,7 @@ integrations.post('/:id/grab', async (c) => {
 		instanceId: number
 		category?: string
 		savepath?: string
+		downloadPath?: string
 	}>()
 
 	if (!body.instanceId) {
@@ -248,6 +249,9 @@ integrations.post('/:id/grab', async (c) => {
 		}
 		if (body.savepath) {
 			formData.append('savepath', body.savepath)
+		}
+		if (body.downloadPath) {
+			formData.append('downloadPath', body.downloadPath)
 		}
 
 		if (body.magnetUrl) {
@@ -292,3 +296,4 @@ integrations.post('/:id/grab', async (c) => {
 })
 
 export default integrations
+

--- a/src/types/qbittorrent.ts
+++ b/src/types/qbittorrent.ts
@@ -40,6 +40,7 @@ export interface Torrent {
 	completion_on: number
 	last_activity: number
 	save_path: string
+	download_path: string
 	downloaded: number
 	uploaded: number
 	tracker: string

--- a/src/types/torrentDetails.ts
+++ b/src/types/torrentDetails.ts
@@ -1,5 +1,6 @@
 export interface TorrentProperties {
 	save_path: string
+	download_path: string
 	creation_date: number
 	piece_size: number
 	comment: string


### PR DESCRIPTION
This PR adds below features:

1. Added "download path" option while grabbing a torrent from prowlarr search. (save path option was already available here)
2. Added two new options in torrent details view to change save path and download path.
3. Torrent details view now shows both currently set save path and download path.
4. Added two new options in right click menu on a torrent to change save path and download path.
5. Current action toolbar doesn't fit properly on iPad screen in portrait mode. With this PR now action toolbar is scrollable. 

All changes are verified on Desktop, Android mobile and iPad.