### PR TITLE
Fix the download path not showing in torrent details screen when its same as save path.

### DIFF
--- a/src/components/TorrentDetailsPanel.tsx
+++ b/src/components/TorrentDetailsPanel.tsx
@@ -269,7 +269,7 @@ function GeneralTab({ hash, category, tags }: { hash: string; category: string; 
 						Edit
 					</button>
 				</div>
-				{properties.download_path && properties.download_path !== properties.save_path && (
+				{properties.download_path && (properties.download_path !== properties.save_path || properties.pieces_have < properties.pieces_num) && (
 					<div className="mt-1.5 px-3 py-2 rounded border flex items-start gap-3" style={cellBase}>
 						<div className="flex-1 min-w-0">
 							<div className="text-[9px] uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
@@ -904,5 +904,6 @@ export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onTo
 		</div>
 	)
 }
+
 
 

--- a/src/mobile/MobileTorrentDetail.tsx
+++ b/src/mobile/MobileTorrentDetail.tsx
@@ -308,7 +308,7 @@ export function MobileTorrentDetail({ torrentHash, instanceId, onClose }: Props)
 										onEdit={() => openPathEditor('savePath')}
 										editDisabled={pathMutationPending}
 									/>
-									{torrent.download_path && torrent.download_path !== torrent.save_path && (
+									{torrent.download_path && (torrent.download_path !== torrent.save_path || torrent.progress < 1) && (
 										<PathRow
 											label="Download Path"
 											value={torrent.download_path}
@@ -615,4 +615,5 @@ function PathRow({
 		</div>
 	)
 }
+
 


### PR DESCRIPTION
When both download & save paths are the same and the torrent is still downloading, the download path and its edit button are hidden. The fix is to also show the download path when the torrent is in progress, regardless of whether it matches the save path.