### PR TITLE
Added ability to multi-select torrents.

### DIFF
--- a/src/components/TorrentDetailsPanel.tsx
+++ b/src/components/TorrentDetailsPanel.tsx
@@ -37,6 +37,7 @@ interface Props {
 	onToggle: () => void
 	height: number
 	onHeightChange: (h: number) => void
+	selectedCount?: number
 }
 
 type Tab = 'general' | 'trackers' | 'peers' | 'http' | 'content'
@@ -767,7 +768,7 @@ function ContentTab({ hash }: { hash: string }) {
 	return <ContentTabInner key={hash} hash={hash} files={files} />
 }
 
-export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onToggle, height, onHeightChange }: Props) {
+export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onToggle, height, onHeightChange, selectedCount = 0 }: Props) {
 	const [tab, setTab] = useState<Tab>('general')
 	const [dragging, setDragging] = useState(false)
 	const dragStartY = useRef(0)
@@ -894,7 +895,7 @@ export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onTo
 							<div className="text-center">
 								<MousePointer className="w-8 h-8 mx-auto mb-2" style={{ color: 'var(--border)' }} strokeWidth={1} />
 								<p className="text-xs uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
-									Select a torrent
+									{selectedCount > 1 ? `${selectedCount} torrents selected` : 'Select a torrent'}
 								</p>
 							</div>
 						</div>
@@ -904,5 +905,6 @@ export function TorrentDetailsPanel({ hash, name, category, tags, expanded, onTo
 		</div>
 	)
 }
+
 
 

--- a/src/components/TorrentList.tsx
+++ b/src/components/TorrentList.tsx
@@ -418,6 +418,16 @@ export function TorrentList() {
 		}
 	}
 
+	function handleCheckboxToggle(hash: string) {
+		setSelected((prev) => {
+			const next = new Set(prev)
+			if (next.has(hash)) next.delete(hash)
+			else next.add(hash)
+			return next
+		})
+		setLastSelected(hash)
+	}
+
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
 			if (e.key === 'Escape') {
@@ -741,6 +751,7 @@ export function TorrentList() {
 									torrent={t}
 									selected={selected.has(t.hash)}
 									onSelect={handleSelect}
+									onCheckboxToggle={handleCheckboxToggle}
 									onContextMenu={(e) => handleContextMenu(e, t)}
 									ratioThreshold={ratioThreshold}
 									hideAddedTime={hideAddedTime}
@@ -839,6 +850,7 @@ export function TorrentList() {
 					onToggle={() => setPanelExpanded(!panelExpanded)}
 					height={panelHeight}
 					onHeightChange={setPanelHeight}
+					selectedCount={selected.size}
 				/>
 			</Suspense>
 
@@ -877,4 +889,5 @@ export function TorrentList() {
 		</div>
 	)
 }
+
 

--- a/src/components/TorrentRow.tsx
+++ b/src/components/TorrentRow.tsx
@@ -274,6 +274,7 @@ interface Props {
 	torrent: Torrent
 	selected: boolean
 	onSelect: (hash: string, multi: boolean, range: boolean) => void
+	onCheckboxToggle: (hash: string) => void
 	onContextMenu: (e: React.MouseEvent) => void
 	ratioThreshold: number
 	hideAddedTime: boolean
@@ -287,6 +288,7 @@ export function TorrentRow({
 	torrent,
 	selected,
 	onSelect,
+	onCheckboxToggle,
 	onContextMenu,
 	ratioThreshold,
 	hideAddedTime,
@@ -321,7 +323,11 @@ export function TorrentRow({
 			>
 				<div className="flex items-center gap-3">
 					<div
-						className="shrink-0 w-4 h-4 rounded border transition-colors duration-150 flex items-center justify-center"
+						onClick={(e) => {
+							e.stopPropagation()
+							onCheckboxToggle(torrent.hash)
+						}}
+						className="shrink-0 w-4 h-4 rounded border transition-colors duration-150 flex items-center justify-center cursor-pointer"
 						style={{
 							borderColor: selected ? 'var(--text-muted)' : 'var(--border)',
 							backgroundColor: selected ? 'color-mix(in srgb, white 3%, transparent)' : 'transparent',
@@ -353,3 +359,4 @@ export function TorrentRow({
 		</tr>
 	)
 }
+

--- a/src/mobile/MobileTorrentList.tsx
+++ b/src/mobile/MobileTorrentList.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import {
 	ChevronDown,
 	ArrowDown,
@@ -10,6 +10,10 @@ import {
 	LayoutGrid,
 	List,
 	Archive,
+	Square,
+	Trash2,
+	X,
+	Check,
 } from 'lucide-react'
 import { useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import * as api from '../api/qbittorrent'
@@ -172,6 +176,11 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 	const [status, setStatus] = useState<StatusFilter>('all')
 	const [sortBy, setSortBy] = useState<SortField>('added_on')
 	const [swipedHash, setSwipedHash] = useState<string | null>(null)
+	const [multiSelectMode, setMultiSelectMode] = useState(false)
+	const [selectedHashes, setSelectedHashes] = useState<Set<string>>(new Set())
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+	const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const longPressTriggeredRef = useRef(false)
 	const queryClient = useQueryClient()
 
 	const torrentQueries = useQueries({
@@ -205,6 +214,87 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 			api.startTorrents(instanceId, hashes),
 		onSuccess: (_, { instanceId }) => queryClient.invalidateQueries({ queryKey: ['torrents', instanceId] }),
 	})
+
+	const deleteMutation = useMutation({
+		mutationFn: ({ instanceId, hashes, deleteFiles }: { instanceId: number; hashes: string[]; deleteFiles: boolean }) =>
+			api.deleteTorrents(instanceId, hashes, deleteFiles),
+		onSuccess: (_, { instanceId }) => queryClient.invalidateQueries({ queryKey: ['torrents', instanceId] }),
+	})
+
+	const getSelectedTorrents = useCallback(() => {
+		return torrents.filter((t) => selectedHashes.has(t.hash))
+	}, [torrents, selectedHashes])
+
+	const groupByInstance = useCallback((selected: TorrentWithInstance[]) => {
+		const groups = new Map<number, string[]>()
+		for (const t of selected) {
+			const arr = groups.get(t.instanceId) || []
+			arr.push(t.hash)
+			groups.set(t.instanceId, arr)
+		}
+		return groups
+	}, [])
+
+	function handleBulkStart() {
+		const groups = groupByInstance(getSelectedTorrents())
+		groups.forEach((hashes, instanceId) => startMutation.mutate({ instanceId, hashes }))
+	}
+
+	function handleBulkStop() {
+		const groups = groupByInstance(getSelectedTorrents())
+		groups.forEach((hashes, instanceId) => stopMutation.mutate({ instanceId, hashes }))
+	}
+
+	function handleBulkDelete(deleteFiles: boolean) {
+		const groups = groupByInstance(getSelectedTorrents())
+		groups.forEach((hashes, instanceId) => deleteMutation.mutate({ instanceId, hashes, deleteFiles }))
+		setSelectedHashes(new Set())
+		setMultiSelectMode(false)
+		setShowDeleteConfirm(false)
+	}
+
+	function exitMultiSelect() {
+		setMultiSelectMode(false)
+		setSelectedHashes(new Set())
+	}
+
+	function handleTorrentTap(torrent: TorrentWithInstance) {
+		if (multiSelectMode) {
+			setSelectedHashes((prev) => {
+				const next = new Set(prev)
+				if (next.has(torrent.hash)) next.delete(torrent.hash)
+				else next.add(torrent.hash)
+				if (next.size === 0) setMultiSelectMode(false)
+				return next
+			})
+		} else {
+			onSelectTorrent(torrent.hash, torrent.instanceId)
+		}
+	}
+
+	function handleLongPressStart(torrent: TorrentWithInstance) {
+		longPressTriggeredRef.current = false
+		longPressTimerRef.current = setTimeout(() => {
+			longPressTriggeredRef.current = true
+			setMultiSelectMode(true)
+			setSelectedHashes((prev) => new Set(prev).add(torrent.hash))
+			if (navigator.vibrate) navigator.vibrate(50)
+		}, 500)
+	}
+
+	function handleLongPressEnd() {
+		if (longPressTimerRef.current) {
+			clearTimeout(longPressTimerRef.current)
+			longPressTimerRef.current = null
+		}
+	}
+
+	function handleLongPressMove() {
+		if (longPressTimerRef.current) {
+			clearTimeout(longPressTimerRef.current)
+			longPressTimerRef.current = null
+		}
+	}
 
 	const filteredTorrents = useMemo(() => {
 		let result = torrents
@@ -294,14 +384,32 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 						const progress = Math.round(torrent.progress * 100)
 
 						if (compact) {
+							const isSelected = selectedHashes.has(torrent.hash)
 							return (
 								<button
 									key={torrent.hash}
-									onClick={() => onSelectTorrent(torrent.hash, torrent.instanceId)}
+									onClick={() => handleTorrentTap(torrent)}
+									onTouchStart={() => handleLongPressStart(torrent)}
+									onTouchEnd={handleLongPressEnd}
+									onTouchMove={handleLongPressMove}
 									className="w-full text-left px-3 py-2.5 rounded-xl border active:scale-[0.99] transition-transform"
-									style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+									style={{
+										backgroundColor: isSelected ? 'color-mix(in srgb, var(--accent) 12%, var(--bg-secondary))' : 'var(--bg-secondary)',
+										borderColor: isSelected ? 'var(--accent)' : 'var(--border)',
+									}}
 								>
 									<div className="flex items-center gap-2 mb-1">
+										{multiSelectMode && (
+											<div
+												className="shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors"
+												style={{
+													borderColor: isSelected ? 'var(--accent)' : 'var(--border)',
+													backgroundColor: isSelected ? 'var(--accent)' : 'transparent',
+												}}
+											>
+												{isSelected && <Check className="w-3 h-3" style={{ color: 'var(--accent-contrast)' }} strokeWidth={3} />}
+											</div>
+										)}
 										<div className="text-xs font-medium truncate flex-1" style={{ color: 'var(--text-primary)' }}>
 											{torrent.name}
 										</div>
@@ -378,6 +486,7 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 
 						return (
 							<div key={torrent.hash} className="relative overflow-hidden rounded-2xl">
+								{!multiSelectMode && (
 								<div
 									className="absolute inset-y-0 right-0 flex items-center px-4 transition-transform"
 									style={{
@@ -393,28 +502,60 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 										)}
 									</button>
 								</div>
+								)}
 
 								<button
-									onClick={() => onSelectTorrent(torrent.hash, torrent.instanceId)}
-									onTouchStart={() => {}}
+									onClick={(e) => {
+										if (longPressTriggeredRef.current) {
+											e.preventDefault()
+											return
+										}
+										handleTorrentTap(torrent)
+									}}
+									onTouchStart={() => handleLongPressStart(torrent)}
+									onTouchEnd={handleLongPressEnd}
+									onTouchMove={handleLongPressMove}
 									onContextMenu={(e) => {
 										e.preventDefault()
-										setSwipedHash(isSwiped ? null : torrent.hash)
+										if (!multiSelectMode) setSwipedHash(isSwiped ? null : torrent.hash)
 									}}
 									className="w-full text-left p-4 rounded-2xl border transition-transform active:scale-[0.98]"
 									style={{
-										backgroundColor: 'var(--bg-secondary)',
-										borderColor: 'var(--border)',
-										transform: isSwiped ? 'translateX(-60px)' : 'translateX(0)',
+										backgroundColor: selectedHashes.has(torrent.hash) ? 'color-mix(in srgb, var(--accent) 12%, var(--bg-secondary))' : 'var(--bg-secondary)',
+										borderColor: selectedHashes.has(torrent.hash) ? 'var(--accent)' : 'var(--border)',
+										transform: isSwiped && !multiSelectMode ? 'translateX(-60px)' : 'translateX(0)',
 									}}
 								>
 									<div className="flex items-start gap-3">
+										{multiSelectMode ? (
+											<div
+												className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+												style={{
+													backgroundColor: selectedHashes.has(torrent.hash)
+														? 'color-mix(in srgb, var(--accent) 20%, transparent)'
+														: 'var(--bg-tertiary)',
+												}}
+											>
+												<div
+													className="w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors"
+													style={{
+														borderColor: selectedHashes.has(torrent.hash) ? 'var(--accent)' : 'var(--border)',
+														backgroundColor: selectedHashes.has(torrent.hash) ? 'var(--accent)' : 'transparent',
+													}}
+												>
+													{selectedHashes.has(torrent.hash) && (
+														<Check className="w-3.5 h-3.5" style={{ color: 'var(--accent-contrast)' }} strokeWidth={3} />
+													)}
+												</div>
+											</div>
+										) : (
 										<div
 											className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
 											style={{ backgroundColor: `color-mix(in srgb, ${stateInfo.color} 15%, transparent)` }}
 										>
 											<StateIcon type={stateInfo.icon} color={stateInfo.color} />
 										</div>
+										)}
 										<div className="flex-1 min-w-0">
 											<div
 												className="font-medium text-sm leading-snug line-clamp-2"
@@ -540,6 +681,114 @@ export function MobileTorrentList({ instances, search, compact, onToggleCompact,
 					})}
 				</div>
 			)}
+
+			{multiSelectMode && (
+				<div
+					className="fixed bottom-[calc(70px+env(safe-area-inset-bottom,0px)+12px)] left-4 right-4 z-40 flex items-center gap-2 px-4 py-3 rounded-2xl border shadow-2xl backdrop-blur-xl"
+					style={{
+						backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 95%, transparent)',
+						borderColor: 'var(--border)',
+					}}
+				>
+					<button
+						onClick={exitMultiSelect}
+						className="w-9 h-9 rounded-xl flex items-center justify-center active:scale-95 transition-transform"
+						style={{ backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-muted)' }}
+						title="Cancel"
+					>
+						<X className="w-5 h-5" strokeWidth={2} />
+					</button>
+
+					<span className="text-xs font-medium tabular-nums" style={{ color: 'var(--text-muted)' }}>
+						{selectedHashes.size} selected
+					</span>
+
+					<div className="flex-1" />
+
+					<button
+						onClick={handleBulkStart}
+						disabled={selectedHashes.size === 0}
+						className="w-10 h-10 rounded-xl flex items-center justify-center active:scale-95 transition-transform disabled:opacity-40"
+						style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 15%, transparent)', color: 'var(--accent)' }}
+						title="Start / Resume"
+					>
+						<Play className="w-5 h-5" strokeWidth={2} />
+					</button>
+
+					<button
+						onClick={handleBulkStop}
+						disabled={selectedHashes.size === 0}
+						className="w-10 h-10 rounded-xl flex items-center justify-center active:scale-95 transition-transform disabled:opacity-40"
+						style={{ backgroundColor: 'color-mix(in srgb, var(--warning) 15%, transparent)', color: 'var(--warning)' }}
+						title="Stop"
+					>
+						<Square className="w-5 h-5" strokeWidth={2} />
+					</button>
+
+					<button
+						onClick={() => setShowDeleteConfirm(true)}
+						disabled={selectedHashes.size === 0}
+						className="w-10 h-10 rounded-xl flex items-center justify-center active:scale-95 transition-transform disabled:opacity-40"
+						style={{ backgroundColor: 'color-mix(in srgb, var(--error) 15%, transparent)', color: 'var(--error)' }}
+						title="Delete"
+					>
+						<Trash2 className="w-5 h-5" strokeWidth={2} />
+					</button>
+				</div>
+			)}
+
+			{showDeleteConfirm && (
+				<div
+					className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
+					style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+					onClick={() => setShowDeleteConfirm(false)}
+				>
+					<div
+						className="w-full max-w-xs mx-4 rounded-2xl p-5 border shadow-2xl"
+						style={{ backgroundColor: 'var(--bg-secondary)', borderColor: 'var(--border)' }}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h3 className="text-sm font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>
+							Delete {selectedHashes.size} torrent{selectedHashes.size > 1 ? 's' : ''}?
+						</h3>
+						<p className="text-xs mb-4" style={{ color: 'var(--text-muted)' }}>
+							This action cannot be undone.
+						</p>
+						<div className="space-y-2">
+							<button
+								onClick={() => handleBulkDelete(false)}
+								className="w-full py-2.5 rounded-xl border text-sm font-medium active:scale-[0.98] transition-transform"
+								style={{
+									backgroundColor: 'color-mix(in srgb, var(--error) 10%, transparent)',
+									borderColor: 'color-mix(in srgb, var(--error) 20%, transparent)',
+									color: 'var(--error)',
+								}}
+							>
+								Remove from list
+							</button>
+							<button
+								onClick={() => handleBulkDelete(true)}
+								className="w-full py-2.5 rounded-xl text-sm font-medium text-white active:scale-[0.98] transition-transform"
+								style={{ backgroundColor: 'var(--error)' }}
+							>
+								Delete with files
+							</button>
+							<button
+								onClick={() => setShowDeleteConfirm(false)}
+								className="w-full py-2.5 rounded-xl border text-sm font-medium active:scale-[0.98] transition-transform"
+								style={{
+									backgroundColor: 'var(--bg-tertiary)',
+									borderColor: 'var(--border)',
+									color: 'var(--text-muted)',
+								}}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
 		</div>
 	)
 }
+


### PR DESCRIPTION
### Desktop UI:

1. Checkbox toggle without Ctrl: The checkbox in each row now has its own onClick handler that toggles selection independently of the row click. Clicking the checkbox adds/removes the torrent from selection without needing Ctrl. Clicking elsewhere on the row still works with the existing single/Ctrl/Shift selection logic.
2. Multi-select detail panel: When multiple torrents are selected, the details panel shows "N torrents selected" instead of "Select a torrent". Single-torrent selection still shows the full detail view (existing behavior preserved).

### Mobile UI:

1. Long-press to multiselect: A 500ms touch-hold on any torrent card enters multiselect mode and selects that torrent. Includes haptic feedback.
2. Tap to toggle in multiselect mode: When multiselect is active, tapping a torrent toggles its selection instead of opening the detail drawer. If all torrents are deselected, multiselect mode automatically turns off.
3. Visual selection indicators: Selected cards get an accent-colored border/background. In expanded mode, the state icon is replaced with a checkmark circle. In compact mode, a checkbox circle appears before the name.
4. Floating action toolbar: When in multiselect mode, a fixed toolbar appears above the bottom navigation with:
4.1. X button to cancel multiselect
4.2. Selection count display
4.3. Play (start/resume), Square (stop), Trash (delete) action buttons
4.4. All actions are grouped by instance and applied to all selected torrents
5. Delete confirmation modal: Delete shows a confirmation dialog with "Remove from list" and "Delete with files" options, matching the desktop delete modal pattern.
6. Swipe disabled in multiselect: The swipe-to-toggle gesture is hidden during multiselect mode to avoid conflicts.