### PR TITLE
fix: support QBT_SID_<port> session cookie in network agent proxy

### DIFF
--- a/__tests__/server/proxy.test.ts
+++ b/__tests__/server/proxy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { extractQbtSessionToken } from '../../src/server/routes/proxy'
+
+describe('extractQbtSessionToken', () => {
+    describe('qBittorrent cookie formats', () => {
+        it('extracts value from legacy SID cookie (qBittorrent < 5.2)', () => {
+            expect(extractQbtSessionToken('SID=abc123')).toBe('abc123')
+        })
+
+        it('extracts value from QBT_SID_8081 cookie (qBittorrent 5.2.x, port 8081)', () => {
+            expect(extractQbtSessionToken('QBT_SID_8081=abc123')).toBe('abc123')
+        })
+
+        it('extracts value from QBT_SID_443 cookie (qBittorrent 5.2.x, port 443)', () => {
+            expect(extractQbtSessionToken('QBT_SID_443=abc123')).toBe('abc123')
+        })
+
+        it('extracts value from arbitrary high port QBT_SID cookie', () => {
+            expect(extractQbtSessionToken('QBT_SID_12345=abc123')).toBe('abc123')
+        })
+    })
+
+    describe('full Set-Cookie value', () => {
+        it('strips attributes after the first semicolon', () => {
+            expect(extractQbtSessionToken('QBT_SID_8081=abc123; Path=/; HttpOnly')).toBe('abc123')
+        })
+
+        it('strips attributes for legacy SID cookie', () => {
+            expect(extractQbtSessionToken('SID=abc123; Path=/; HttpOnly')).toBe('abc123')
+        })
+    })
+
+    describe('cookie name validation', () => {
+        it('rejects a cookie whose name does not contain SID', () => {
+            expect(extractQbtSessionToken('theme=dark')).toBe('')
+        })
+
+        it('picks the SID cookie out of multiple cookies', () => {
+            expect(extractQbtSessionToken('theme=dark; SID=abc123; lang=en')).toBe('abc123')
+        })
+
+        it('picks the QBT_SID cookie out of multiple cookies', () => {
+            expect(extractQbtSessionToken('theme=dark; QBT_SID_8081=abc123')).toBe('abc123')
+        })
+
+        it('does not match lowercase sid in another cookie name', () => {
+            expect(extractQbtSessionToken('resident=user; theme=dark')).toBe('')
+        })
+    })
+
+    describe('value edge cases', () => {
+        it('preserves equals signs inside the session value', () => {
+            expect(extractQbtSessionToken('SID=abc==def')).toBe('abc==def')
+        })
+
+        it('handles values that look like base64 padding', () => {
+            expect(extractQbtSessionToken('QBT_SID_8081=YWJj==')).toBe('YWJj==')
+        })
+    })
+
+    describe('invalid input', () => {
+        it('returns empty string for null', () => {
+            expect(extractQbtSessionToken(null)).toBe('')
+        })
+
+        it('returns empty string for undefined', () => {
+            expect(extractQbtSessionToken(undefined)).toBe('')
+        })
+
+        it('returns empty string for empty string', () => {
+            expect(extractQbtSessionToken('')).toBe('')
+        })
+
+        it('returns empty string when no equals sign is present', () => {
+            expect(extractQbtSessionToken('malformed-cookie')).toBe('')
+        })
+    })
+})

--- a/src/server/routes/proxy.ts
+++ b/src/server/routes/proxy.ts
@@ -143,6 +143,23 @@ function getAgentUrl(instance: Instance): string {
 	return url.origin
 }
 
+export function extractQbtSessionToken(cookie: string | null | undefined): string {
+	if (!cookie) return ''
+
+	const sessionCookie = cookie
+		.split(';')
+		.map((part) => part.trim())
+		.find((part) => {
+			const equalsIndex = part.indexOf('=')
+			return equalsIndex > 0 && part.slice(0, equalsIndex).includes('SID')
+		})
+
+	const equalsIndex = sessionCookie?.indexOf('=') ?? -1
+	if (equalsIndex < 0) return ''
+
+	return sessionCookie!.slice(equalsIndex + 1)
+}
+
 proxy.all('/:id/agent/*', async (c) => {
 	const user = c.get('user')
 	const instanceId = Number(c.req.param('id'))
@@ -170,7 +187,7 @@ proxy.all('/:id/agent/*', async (c) => {
 
 	try {
 		const cookie = await getQbtSession(instance)
-		const sid = cookie?.match(/SID=([^;]+)/)?.[1] || ''
+		const sid = extractQbtSessionToken(cookie)
 
 		const headers = new Headers()
 		headers.set('X-QBT-SID', sid)


### PR DESCRIPTION
## Problem

The Network Agent proxy fails against qBittorrent 5.2.x. Every agent request is rejected with:

```json
{"error":"missing SID"}
```

## Root cause

qBittorrent 5.2.x changed the session cookie name from `SID` to `QBT_SID_<port>` (e.g. `QBT_SID_8081`):

```
Set-Cookie: QBT_SID_8081=<token>; Path=/; HttpOnly
```

But `src/server/routes/proxy.ts` extracts the token assuming the cookie is named exactly `SID`:

```ts
const sid = cookie?.match(/SID=([^;]+)/)?.[1] || ''
```

For `QBT_SID_8081=<token>` this yields `''`, so the agent receives `X-QBT-SID:` (empty) and replies `missing SID`.

The login/cookie flow in `src/server/utils/qbt.ts` is correct — only the token extraction before calling the agent is wrong.

## Fix

Replace the regex with a helper that selects the cookie whose name contains `SID` and returns its value:

```ts
export function extractQbtSessionToken(cookie: string | null | undefined): string {
	if (!cookie) return ''

	const sessionCookie = cookie
		.split(';')
		.map((part) => part.trim())
		.find((part) => {
			const equalsIndex = part.indexOf('=')
			return equalsIndex > 0 && part.slice(0, equalsIndex).includes('SID')
		})

	const equalsIndex = sessionCookie?.indexOf('=') ?? -1
	if (equalsIndex < 0) return ''

	return sessionCookie!.slice(equalsIndex + 1)
}
```

## Compatibility

The agent only needs the session *value* (sent as `X-QBT-SID`), not the cookie name, so accepting any `*SID*`-named cookie is correct. Verified against:

| Cookie | Result |
| --- | --- |
| `SID=abc` (legacy, < 5.2) | `abc` |
| `QBT_SID_8081=abc` (5.2.x) | `abc` |
| `QBT_SID_443=abc` | `abc` |
| `QBT_SID_12345=abc` | `abc` |
| `theme=dark` (no SID) | `''` (rejected) |
| `theme=dark; SID=abc` (multi-cookie) | `abc` |

- The name check is **case-sensitive** (`includes('SID')`) on purpose: qBittorrent always emits uppercase `SID`, and case-insensitive matching would false-positive on names like `resident`.
- Uses `indexOf('=')` + `slice` instead of `split('=', 2)` so values containing `=` (e.g. base64 padding) are preserved.

## Testing

Added `__tests__/server/proxy.test.ts` (16 cases). Full suite passes (356/356), `tsc --noEmit` and `eslint` clean.

Verified with qBittorrent v5.2.2 returning `Set-Cookie: QBT_SID_8081=<token>`.